### PR TITLE
Add availability

### DIFF
--- a/app/bnb.rb
+++ b/app/bnb.rb
@@ -58,6 +58,8 @@ class Bnb < Sinatra::Base
     @space = Space.create(title: params[:title],
                           description: params[:description],
                           price: params[:price],
+                          availability_start: params[:availability_start],
+                          availability_end: params[:availability_end],
                           user_id: current_user.id)
     redirect '/spaces'
   end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -3,12 +3,12 @@ class Space
   include DataMapper::Resource
 
   property :id, Serial
-  property :title, String
-  # required: true
-  property :description, String
-  # , required: true
-  property :price, Integer
-  # , required: true
+  property :title, String, required: true
+  property :description, String, required: true
+  property :price, Integer, required: true
+  property :availability_start, Date
+  property :availability_end, Date
+
   belongs_to :user
 
 end

--- a/app/views/list_space.erb
+++ b/app/views/list_space.erb
@@ -2,17 +2,28 @@
 
 <html>
 <h1>
-<title>List a space:</title>
+  <title>List a space:</title>
 </h1>
- <body>
+
+<body>
   <form action="/spaces" method="post">
-    <label for="title">Title</label>
-   <input type="text" name="title">
-    <label for="title">Description</label>
-   <input type="text" name="description">
-    <label for="title">Price per night</label>
-   <input type="text" name="price">
-   <input type="submit" value="List space!">
- </form>
+    <label for="title">Title
+      <input type="text" name="title">
+    </label>
+    <label for="title">Description
+      <input type="text" name="description">
+    </label>
+    <label for="title">Price per night
+      <input type="text" name="price">
+    </label>
+    <label for="availability_start"> Available from
+      <input type="date" name="availability_start">
+    </label>
+    <label for="availability_end"> Available to
+      <input type="date" name="availability_end">
+    </label>
+    <input type="submit" value="List space!">
+  </form>
 </body>
- </html>
+
+</html>

--- a/app/views/spaces.erb
+++ b/app/views/spaces.erb
@@ -17,15 +17,11 @@
 <ul id="spaces">
   <% @spaces.each do |space| %>
     <li>
-      <label for="title">Title:
-       <%= space.title %><br>
-       </label>
-       <label for="description">Description:
-      <%= space.description %><br>
-      </label>
-      <label for="price">Price per night:
-        <%= space.price %><br>
-     </label>
+      Title: <%= space.title %><br>
+      Description: <%= space.description %><br>
+      Price per night: <%= space.price %><br>
+      Available from: <%= space.availability_start %><br>
+      Available to: <%= space.availability_end %><br>
       <form action="/spaces/hire" method="post">
         <input type="hidden" name="space_id" value="<%= space.id %>">
         <label for="date" > Date:

--- a/spec/features/listspace_spec.rb
+++ b/spec/features/listspace_spec.rb
@@ -15,6 +15,8 @@ feature 'list space' do
     expect{ list_space }.to change { Space.count }.by 1
     expect(Space.all.map(&:title)).to include("Highfield House")
     expect(page).to have_content("Highfield House")
+    expect(page).to have_content("Available from: 2018-01-01")
+    expect(page).to have_content("Available to: 2018-12-01")
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,8 @@ def list_space
   fill_in :title, with: "Highfield House"
   fill_in :description, with: "nice house"
   fill_in :price, with: "100"
+  fill_in :availability_start, with: "01/01/2018"
+  fill_in :availability_end, with: "01/12/2018"
   click_button 'List space!'
 end
 


### PR DESCRIPTION
User can add start date and end date for property availability when they list it, and this is shown on the /spaces page. No checking of this when user tries to hire a space implemented yet