### PR TITLE
32 custom layout for signin

### DIFF
--- a/app/bnb.rb
+++ b/app/bnb.rb
@@ -107,14 +107,15 @@ class Bnb < Sinatra::Base
   # sessions routes
 
   get '/sessions/new' do
-    erb(:login)
+    @signin_page = true
+    erb(:signin)
   end
 
   post '/sessions' do
     @user = User.first(username: params[:name])
     if @user.nil? || @user.password != params[:password]
       flash.now[:error] = 'Username or password is incorrect'
-      erb(:login)
+      erb(:signin)
     else
       session[:user_id] = @user.id
       redirect '/users'

--- a/app/bnb.rb
+++ b/app/bnb.rb
@@ -86,6 +86,7 @@ class Bnb < Sinatra::Base
     @requests = current_user.spaces.map { |space| space.requests }.flatten
     @new_requests = @requests.select{ |request| request.approved == nil }
     @approved_requests = @requests.select{ |request| request.approved == true }
+    @my_requests = current_user.requests
     erb(:requests)
   end
 

--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -5,16 +5,18 @@
     </head>
     <body>
       <header>
-        <% if current_user %>
-          <h2>Welcome <%= @current_user.username %></h2>
-          <form action="/sessions" method="post">
-            <input type="hidden" name="_method" value="DELETE">
-            <input type="submit" value="Sign out">
+        <% if not defined? @signin_page %>
+          <% if current_user %>
+            <h2>Welcome <%= @current_user.username %></h2>
+            <form action="/sessions" method="post">
+              <input type="hidden" name="_method" value="DELETE">
+              <input type="submit" value="Sign out">
+            </form>
+          <% else %>
+          <form action="/sessions/new">
+            <input type="submit" value="Sign in">
           </form>
-        <% else %>
-        <form action="/sessions/new">
-          <input type="submit" value="Sign in">
-        </form>
+          <% end %>
         <% end %>
       </header>
       <main>

--- a/app/views/requests.erb
+++ b/app/views/requests.erb
@@ -15,7 +15,7 @@
     <li>
       User: <%= User.get(request.user_id).username %><br>
       Date: <%= request.date %><br>
-      Property: <%= Space.get(request.space_id).title %><br>
+      Space: <%= Space.get(request.space_id).title %><br>
       <form action="/requests" method="post">
         <input type="hidden" name="_method" value="patch">
         <input type="hidden" name="request_id" value="<%= request.id %>">
@@ -41,7 +41,20 @@
     <li>
       User: <%= User.get(request.user_id).username %><br>
       Date: <%= request.date %><br>
-      Property: <%= Space.get(request.space_id).title %><br>
+      Space: <%= Space.get(request.space_id).title %><br>
     </li>
   <% end %>
+</ul>
+
+<ul id="my_requests">
+  <% if !@my_requests.empty? %>
+  <h3>My requests to hire a space:</h3>
+<%end%>
+
+<% @my_requests.each do |request| %>
+  <li>
+    Date: <%= request.date %><br>
+    Space: <%= Space.get(request.space_id).title %><br>
+  </li>
+<% end %>
 </ul>

--- a/app/views/signin.erb
+++ b/app/views/signin.erb
@@ -2,16 +2,16 @@
 <html>
 <head>
 
-  <title>Login</title>
+  <title>Sign in</title>
 
 </head>
 <body>
-  <h3>Please login to MakersBnB</h3>
+  <h3>Please sign in to MakersBnB</h3>
 
   <p>
-      <% if flash[:error] %>
-        <%= flash[:error] %>
-      <% end %>
+    <% if flash[:error] %>
+      <%= flash[:error] %>
+    <% end %>
   </p>
   <form action="/sessions" method="post">
     <label for="name">Username:
@@ -20,7 +20,7 @@
     <label for="password">Password:
       <input type="password" name="password" />
     </label>
-    <input type="submit" value="Log in" />
+    <input type="submit" value="Sign in" />
   </form>
 </body>
 </html>

--- a/spec/features/requests_spec.rb
+++ b/spec/features/requests_spec.rb
@@ -1,4 +1,4 @@
-feature 'user can view requests' do
+feature 'user can view requests to hire their space' do
   scenario 'user can view requests' do
     sign_up(name: 'Owner', email: 'user1@example.com')
     list_space
@@ -113,4 +113,22 @@ feature 'user can accept and deny requests' do
     expect(Request.first.approved).to eq(false) 
   end
 
+end
+
+feature 'user can see their requests to hire someone elses space' do
+  scenario 'user can view requests' do
+    sign_up(name: 'Owner', email: 'user1@example.com')
+    list_space
+    click_button("Sign out")
+    sign_up(name: 'Holidaymaker', email: 'user2@example.com')
+    visit '/spaces'
+    fill_in :date, with: '02/01/2109'
+    click_button 'Request'
+    visit '/requests'
+    within 'ul#my_requests' do
+      expect(page).to have_content("My requests to hire a space:")
+      expect(page).to have_content("2109-01-02")
+      expect(page).to have_content("Highfield House")
+    end
+  end
 end

--- a/spec/features/requests_spec.rb
+++ b/spec/features/requests_spec.rb
@@ -8,7 +8,7 @@ feature 'user can view requests to hire their space' do
     fill_in :date, with: '02/01/2109'
     click_button 'Request'
     click_button("Sign out")
-    login(name: "Owner")
+    signin(name: "Owner")
     visit '/requests'
     within 'ul#new_requests' do
       expect(page).to have_content("You have requests waiting:")
@@ -54,7 +54,7 @@ feature 'user can view requests to hire their space' do
     fill_in :date, with: '02/01/2109'
     click_button 'Request'
     click_button("Sign out")
-    login(name: "Owner")
+    signin(name: "Owner")
     visit '/requests'
     click_button 'Deny'
     expect(page).not_to have_content("You have requests waiting:")
@@ -70,7 +70,7 @@ feature 'user can view requests to hire their space' do
     fill_in :date, with: '02/01/2109'
     click_button 'Request'
     click_button("Sign out")
-    login(name: "Owner")
+    signin(name: "Owner")
     visit '/requests'
     click_button 'Approve'
     within 'ul#approved_requests' do
@@ -90,7 +90,7 @@ feature 'user can accept and deny requests' do
     fill_in :date, with: '02/01/2109'
     click_button 'Request'
     click_button("Sign out")
-    login(name: "Owner")
+    signin(name: "Owner")
     visit '/requests'
     click_button 'Approve'
     expect(page).to have_content("Request approved")
@@ -106,7 +106,7 @@ feature 'user can accept and deny requests' do
     fill_in :date, with: '02/01/2109'
     click_button 'Request'
     click_button("Sign out")
-    login(name: "Owner")
+    signin(name: "Owner")
     visit '/requests'
     click_button 'Deny'
     expect(page).to have_content("Request denied")

--- a/spec/features/signin_spec.rb
+++ b/spec/features/signin_spec.rb
@@ -1,18 +1,18 @@
 feature 'User sign in' do
   scenario 'with correct username & pw' do
     sign_up
-    login
+    signin
     expect(page).to have_content('Welcome Alex')
   end
 
   scenario 'with wrong pw' do
     sign_up
-    login(password: 'wrongpassword')
+    signin(password: 'wrongpassword')
     expect(page).to have_content('Username or password is incorrect')
   end
 
   scenario 'when user does not exist' do
-    login
+    signin
     expect(page).to have_content('Username or password is incorrect')
   end
 
@@ -21,7 +21,7 @@ feature 'User sign in' do
     click_button("Sign out")
     sign_up(name: 'User2', email: 'user2@example.com')
     click_button("Sign out")
-    login(name: 'User2')
+    signin(name: 'User2')
     expect(page).to have_content('Welcome User2')
   end
 

--- a/spec/features/signout_spec.rb
+++ b/spec/features/signout_spec.rb
@@ -1,7 +1,7 @@
 feature "sign out" do
   scenario "signs out when user clicks button" do
     sign_up
-    login
+    signin
     visit '/spaces'
     click_button "Sign out"
     expect(page).to have_button('Sign in')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,11 +21,11 @@ fill_in 'password_confirmation', with: password_confirmation
 click_button 'Sign up!'
 end
 
-def login(name: 'Alex', password: 'password123')
+def signin(name: 'Alex', password: 'password123')
   visit '/sessions/new'
   fill_in 'name', with: name
   fill_in 'password', with: password
-  click_button 'Log in'
+  click_button 'Sign in'
 end
 
 def list_space


### PR DESCRIPTION
Disable 'sign in' button in header on sign in page & rename 'login' to 'sign in' throughout project.

Closes #32 